### PR TITLE
fix: throw "lcov is empty" instead of "parsing error!"

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function run() {
 
   parse(lcovPath, (err, data) => {
     if (typeof data === 'undefined') {
-      core.setFailed(`parsing error!`);
+      core.setFailed('parsing error!');
       return;
     }
 

--- a/index.js
+++ b/index.js
@@ -71,14 +71,12 @@ function shouldCalculateCoverageForFile(fileName, excludedFiles) {
 }
 
 function canParse(path) {
-  let result = true;
-  
   if (fs.existsSync(path) && fs.readFileSync(path).length === 0) {
     core.setFailed('lcov is empty!');
-    result = false;
+    return false;
   }
 
-  return result;
+  return true;
 }
 
 run();

--- a/index.js
+++ b/index.js
@@ -9,8 +9,7 @@ function run() {
   const excluded = core.getInput('exclude');
   const excludedFiles = excluded.split(' ');
 
-  const errorCallback = (errorMessage) => core.setFailed(errorMessage);
-  if (!canParse(lcovPath, errorCallback)) {
+  if (!canParse(lcovPath)) {
     return;
   }
 
@@ -71,11 +70,11 @@ function shouldCalculateCoverageForFile(fileName, excludedFiles) {
   return true;
 }
 
-function canParse(path, errorCallback) {
+function canParse(path) {
   let result = true;
   
   if (fs.existsSync(path) && fs.readFileSync(path).length === 0) {
-    errorCallback('lcov is empty!');
+    core.setFailed('lcov is empty!');
     result = false;
   }
 

--- a/index.test.js
+++ b/index.test.js
@@ -12,6 +12,21 @@ const getErrorOutput = (error) => {
   return output;
 };
 
+test('empty LCOV throws an error', () => {
+  const lcovPath = './fixtures/lcov.empty.info';
+  process.env['INPUT_PATH'] = lcovPath;
+  const ip = path.join(__dirname, 'index.js');
+  try {
+    cp.execSync(`node ${ip}`, { env: process.env });
+    fail('this code should fail');
+  } catch (err) {
+    expect(err).toBeDefined();
+
+    const errorMessage = err.stdout.toString();
+    expect(errorMessage).toContain('lcov is empty!');
+  }
+});
+
 test('invalid LCOV format throws an error', () => {
   const lcovPath = './fixtures/lcov.error.info';
   process.env['INPUT_PATH'] = lcovPath;
@@ -21,6 +36,9 @@ test('invalid LCOV format throws an error', () => {
     fail('this code should fail');
   } catch (err) {
     expect(err).toBeDefined();
+
+    const errorMessage = err.stdout.toString();
+    expect(errorMessage).toContain('parsing error!');
   }
 });
 


### PR DESCRIPTION
## Description

Throws a "lcov is empty!" error message instead of "parsing error!" when the coverage file is empty. Attempts to resolve #95.

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

